### PR TITLE
reduce memory use in HilbertCurve.toIndex 

### DIFF
--- a/src/main/java/org/davidmoten/hilbert/HilbertCurve.java
+++ b/src/main/java/org/davidmoten/hilbert/HilbertCurve.java
@@ -264,13 +264,13 @@ public final class HilbertCurve {
     // single number.
     @VisibleForTesting
     BigInteger toIndex(long... transposedIndex) {
-        byte[] b = new byte[length];
+        byte[] b = new byte[length / 8 + 1];
         int bIndex = length - 1;
         long mask = 1L << (bits - 1);
         for (int i = 0; i < bits; i++) {
             for (int j = 0; j < transposedIndex.length; j++) {
                 if ((transposedIndex[j] & mask) != 0) {
-                    b[length - 1 - bIndex / 8] |= 1 << (bIndex % 8);
+                    b[b.length - 1 - bIndex / 8] |= 1 << (bIndex % 8);
                 }
                 bIndex--;
             }


### PR DESCRIPTION
As raised in #68, HilbertCurve.toIndex allocates more memory than needed so that the BigInteger gets formed from an array with a lot of padding on the left with zeroes. This PR reduces the size of the byte array roughly by a factor of 8. 

Benchmarks show a possible 8% increase in `HilbertCurve.toIndex` throughput.

Before:
```
Benchmarks.toIndexAllPoints10Bits1024Calls                      thrpt   10   2961.022 ±  6.854  ops/s
```
After:
```
Benchmarks.toIndexAllPoints10Bits1024Calls                      thrpt   10   3191.580 ±  6.248  ops/s
```

**All benchmarks**

Before:
```
Benchmark                                                        Mode  Cnt      Score    Error  Units
Benchmarks.pointAllPoints10Bits1024Calls                        thrpt   10   2878.476 ±  3.443  ops/s
Benchmarks.pointAllPoints10Bits1024CallsLowAllocation           thrpt   10   3016.823 ±  3.716  ops/s
Benchmarks.pointSmallAllPoints10Bits1024Calls                   thrpt   10   3387.263 ±  5.278  ops/s
Benchmarks.pointSmallAllPoints10Bits1024CallsLowAllocation      thrpt   10   4377.601 ± 12.116  ops/s
Benchmarks.querySydney                                          thrpt   10  50456.013 ± 76.895  ops/s
Benchmarks.querySydneyMaxRanges8                                thrpt   10  45051.412 ± 84.688  ops/s
Benchmarks.roundTripAllPoints10Bits1024Calls                    thrpt   10   1440.819 ±  2.420  ops/s
Benchmarks.roundTripAllPoints10Bits1024CallsLowAllocation       thrpt   10   1516.848 ±  1.993  ops/s
Benchmarks.roundTripSmallAllPoints10Bits1024Calls               thrpt   10   1890.765 ±  3.175  ops/s
Benchmarks.roundTripSmallAllPoints10Bits1024CallsLowAllocation  thrpt   10   2324.761 ±  6.071  ops/s
Benchmarks.toIndexAllPoints10Bits1024Calls                      thrpt   10   2961.022 ±  6.854  ops/s
Benchmarks.toIndexAllPoints10Bits1024CallsSmall                 thrpt   10   3911.140 ±  2.808  ops/s
```

After:
```
Benchmark                                                        Mode  Cnt      Score    Error  Units
Benchmarks.pointAllPoints10Bits1024Calls                        thrpt   10   2785.858 ±  2.905  ops/s
Benchmarks.pointAllPoints10Bits1024CallsLowAllocation           thrpt   10   3005.200 ±  6.080  ops/s
Benchmarks.pointSmallAllPoints10Bits1024Calls                   thrpt   10   3368.497 ±  5.229  ops/s
Benchmarks.pointSmallAllPoints10Bits1024CallsLowAllocation      thrpt   10   4384.501 ±  8.962  ops/s
Benchmarks.querySydney                                          thrpt   10  46247.517 ± 78.994  ops/s
Benchmarks.querySydneyMaxRanges8                                thrpt   10  45805.742 ± 79.766  ops/s
Benchmarks.roundTripAllPoints10Bits1024Calls                    thrpt   10   1600.639 ±  1.721  ops/s
Benchmarks.roundTripAllPoints10Bits1024CallsLowAllocation       thrpt   10   1601.182 ±  1.517  ops/s
Benchmarks.roundTripSmallAllPoints10Bits1024Calls               thrpt   10   1899.313 ±  4.493  ops/s
Benchmarks.roundTripSmallAllPoints10Bits1024CallsLowAllocation  thrpt   10   2274.926 ±  5.835  ops/s
Benchmarks.toIndexAllPoints10Bits1024Calls                      thrpt   10   3191.580 ±  6.248  ops/s
Benchmarks.toIndexAllPoints10Bits1024CallsSmall                 thrpt   10   3896.921 ±  8.909  ops/s
```